### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/boilerplate.py
+++ b/boilerplate.py
@@ -33,14 +33,14 @@ def main(stdin, stdout, select='w3c-html', branch="master"):
       content = open(os.path.join(bp_dir, name)).read()
     else:
       content = match.group(0)
-      sys.stderr.write("Missing file: %s\n" % name)
+      sys.stderr.write("Missing file: {0!s}\n".format(name))
 
     # use content as the replacement
     return content
   header = re.sub('<!--BOILERPLATE ([-.\w]+)-->', boilerplate, header)
 
   source = stdin.read()
-  source = re.compile('^.*?<!--START %s-->' % select, re.DOTALL).sub('', source)
+  source = re.compile('^.*?<!--START {0!s}-->'.format(select), re.DOTALL).sub('', source)
   source = re.sub('<!--BOILERPLATE ([-.\w]+)-->', boilerplate, source)
 
   content =  header.decode("utf8") + source.decode("utf8")
@@ -52,7 +52,7 @@ def main(stdin, stdout, select='w3c-html', branch="master"):
     def adjust_header(match):
       slash = match.group(1)
       n = int(match.group(2)) - delta
-      return "<%sh%d>" % (slash, n)
+      return "<{0!s}h{1:d}>".format(slash, n)
 
     headers = re.compile("<(/?)h([0-6])>", re.IGNORECASE)
     before = text[0:pos]
@@ -69,7 +69,7 @@ def main(stdin, stdout, select='w3c-html', branch="master"):
     current_position = 0
     adjustment = 0
 
-    fixups = re.compile("<!--FIXUP %s ([+-])([0-9])-->" % select)
+    fixups = re.compile("<!--FIXUP {0!s} ([+-])([0-9])-->".format(select))
 
     fixup = fixups.search(content, current_position)
     while fixup is not None:
@@ -92,8 +92,8 @@ def main(stdin, stdout, select='w3c-html', branch="master"):
     return content
   content = process_fixup(content)
 
-  content = re.compile('<!--END %s-->.*?<!--START %s-->' % (select,select), re.DOTALL).sub('', content)
-  content = re.compile('<!--END %s-->.*' % select, re.DOTALL).sub('', content)
+  content = re.compile('<!--END {0!s}-->.*?<!--START {1!s}-->'.format(select, select), re.DOTALL).sub('', content)
+  content = re.compile('<!--END {0!s}-->.*'.format(select), re.DOTALL).sub('', content)
 
   content = re.sub('<!--(START|END) [-\w]+-->\n?', '', content)
 

--- a/bs.py
+++ b/bs.py
@@ -23,7 +23,7 @@ def main(stdin, stdout):
   def unicode_replacement(matchobj):
     groups = list(matchobj.groups())
     if not groups[1]: groups[1] = ''
-    return '"%s" (%s)%s' % (groups[3], groups[0], groups[1])
+    return '"{0!s}" ({1!s}){2!s}'.format(groups[3], groups[0], groups[1])
   source=stdin.read()
   source = original_para.sub(dummy_replacement, source)
   source = cap_a_z.sub(uppercase_ref, source)

--- a/entity_processor_json.py
+++ b/entity_processor_json.py
@@ -12,19 +12,16 @@ def entity_processor_json(input, json):
     if len(points) == 1:
       codepoint = int(points[0], 16)
       if codepoint <= 0xFFFF:
-        data = '"codepoints": [%d], "characters": "\u%0.4X"' %  \
-          (codepoint, codepoint)
+        data = '"codepoints": [{0:d}], "characters": "\u{1:0.4X}"'.format(codepoint, codepoint)
       else:
         highSurrogate = int(math.floor((codepoint - 0x10000) / 0x400) + 0xD800)
         lowSurrogate = int((codepoint - 0x10000) % 0x400 + 0xDC00)
-        data = '"codepoints": [%d], "characters": "\u%0.4X\u%0.4X"' %\
-          (codepoint, highSurrogate, lowSurrogate)
+        data = '"codepoints": [{0:d}], "characters": "\u{1:0.4X}\u{2:0.4X}"'.format(codepoint, highSurrogate, lowSurrogate)
     else:
       points = map(lambda s: int(s, 16), points)
-      data = '"codepoints": [%d, %d], "characters": "\u%0.4X\u%0.4X"' %\
-        (points[0], points[1], points[0], points[1])
+      data = '"codepoints": [{0:d}, {1:d}], "characters": "\u{2:0.4X}\u{3:0.4X}"'.format(points[0], points[1], points[0], points[1])
     if last: json.write(last + ',\n')
-    last = '  "&%s": { %s }' % (name, data)
+    last = '  "&{0!s}": {{ {1!s} }}'.format(name, data)
   json.write(last + "\n")
   json.write('}\n')
 

--- a/interface_index.py
+++ b/interface_index.py
@@ -19,7 +19,7 @@ def interface_index(input, output):
           definitions[name]['partial'].append(id)
         else:
           if 'primary' in definitions[name]:
-            print >> sys.stderr, "duplicate interface definitions for %s" % name
+            print >> sys.stderr, "duplicate interface definitions for {0!s}".format(name)
             sys.exit(1)
           definitions[name]['primary'] = id
     if '</pre>' in line: inpre = False
@@ -28,16 +28,16 @@ def interface_index(input, output):
   for name in sorted(definitions.keys()):
     output.write(" <li><code>")
     if 'primary' in definitions[name]:
-      output.write("<a href=#%s>%s</a>" % (definitions[name]['primary'], name))
+      output.write("<a href=#{0!s}>{1!s}</a>".format(definitions[name]['primary'], name))
     else:
       output.write(name)
     output.write("</code>")
     if 'partial' in definitions[name]:
-      output.write(", <a href=#%s>partial" % definitions[name]['partial'][0])
+      output.write(", <a href=#{0!s}>partial".format(definitions[name]['partial'][0]))
       if len(definitions[name]['partial']) > 1: print " 1",
       output.write("</a>")
       for i in range(1, len(definitions[name]['partial'])):
-        output.write(" <a href=#%s>%s</a>" % (definitions[name]['partial'][i], i))
+        output.write(" <a href=#{0!s}>{1!s}</a>".format(definitions[name]['partial'][i], i))
     output.write("\n")
   output.write("</ul>\n")
 

--- a/parser_microsyntax.py
+++ b/parser_microsyntax.py
@@ -17,7 +17,7 @@ class IdGenerator:
         return re.sub('\s', lambda x: '-', self.title_from_string(string))
 
     def title_from_string(self, string):
-        return ("%s %s" % (self.prefix, string)).lower()
+        return ("{0!s} {1!s}".format(self.prefix, string)).lower()
 
 class Switch(IdGenerator):
     def __init__(self, switch_var, prefix):
@@ -29,20 +29,20 @@ class Switch(IdGenerator):
         self.cases.append(case)
 
     def text(self):
-        return """switch using %s
-%s""" % (self.variable, "\n".join([case.text() for case in self.cases]))
+        return """switch using {0!s}
+{1!s}""".format(self.variable, "\n".join([case.text() for case in self.cases]))
 
     def html(self):
-        return """<dl class=switch>%s
-</dl>""" % "\n".join([case.html() for case in self.cases])
+        return """<dl class=switch>{0!s}
+</dl>""".format("\n".join([case.html() for case in self.cases]))
 
     def varHtml(self):
-        return """<var title="%s">%s</var>""" % (
+        return """<var title="{0!s}">{1!s}</var>""".format(
             self.title_from_string(self.variable), self.variable)
 
 class Case(IdGenerator):
     def __init__(self, case_thingy, switch):
-        IdGenerator.__init__(self, "%s %s:" % (switch.prefix, switch.variable))
+        IdGenerator.__init__(self, "{0!s} {1!s}:".format(switch.prefix, switch.variable))
         self.thingy = case_thingy
         self.conditions = []
         self.switch = switch
@@ -51,20 +51,20 @@ class Case(IdGenerator):
         self.conditions.append(condition)
 
     def text(self):
-        return """  case %s
-%s""" % (self.thingy, "\n".join([condition.text() for condition in self.conditions]))
+        return """  case {0!s}
+{1!s}""".format(self.thingy, "\n".join([condition.text() for condition in self.conditions]))
 
     def html(self):
-        return """<dt>If %s is "%s"</dt>
+        return """<dt>If {0!s} is "{1!s}"</dt>
 <dd>
 <p>Run the appropriate substeps from the following list:</p>
-<dl class=switch>%s
+<dl class=switch>{2!s}
 </dl>
-</dd>""" % (self.switch.varHtml(), self.thingyHtml(),
+</dd>""".format(self.switch.varHtml(), self.thingyHtml(),
             "\n".join([condition.html() for condition in self.conditions]))
 
     def thingyHtml(self):
-        return """<dfn id=%s title="%s">%s</dfn>""" % (
+        return """<dfn id={0!s} title="{1!s}">{2!s}</dfn>""".format(
             self.id_from_string(self.thingy),
             self.title_from_string(self.thingy),
             self.thingy)
@@ -90,21 +90,21 @@ class Condition:
         self.statements.append(statement)
 
     def text(self):
-        return """    %s=%s</dt>
+        return """    {0!s}={1!s}</dt>
 <dd>
-%s
-</dd>""" % (self.variable, self.conditionalText, "\n".join([statement.text() for statement in self.statements]))
+{2!s}
+</dd>""".format(self.variable, self.conditionalText, "\n".join([statement.text() for statement in self.statements]))
 
     def html(self):
-        return """<dt>If %s is %s</dt>
+        return """<dt>If {0!s} is {1!s}</dt>
 <dd>
-%s
-</dd>""" % (self.varHtml(), self.conditionalHtml(), "\n".join([statement.html() for statement in self.statements]))
+{2!s}
+</dd>""".format(self.varHtml(), self.conditionalHtml(), "\n".join([statement.html() for statement in self.statements]))
 
     def varHtml(self, var=None):
         if var is None:
             var = self.variable
-        return """<var title="">%s</var>""" % var
+        return """<var title="">{0!s}</var>""".format(var)
 
     def conditionalHtml(self):
         conditional = ""
@@ -115,7 +115,7 @@ class Condition:
         else:
             conditional = single_characters[self.characters]
         if self.ifunless is not None:
-            conditional += " and %s is %s" % (
+            conditional += " and {0!s} is {1!s}".format(
                 self.varHtml(self.subcondition),
                 "true" if self.ifunless == "if" else "false")
         return conditional
@@ -136,13 +136,13 @@ class Otherwise(Condition):
 
     def text(self):
         return """    otherwise:
-%s""" % "\n".join([statement.text() for statement in self.statements])
+{0!s}""".format("\n".join([statement.text() for statement in self.statements]))
 
     def html(self):
         return """<dt>Otherwise</dt>
 <dd>
-%s
-</dd>""" % "\n".join([statement.html() for statement in self.statements])
+{0!s}
+</dd>""".format("\n".join([statement.html() for statement in self.statements]))
 
 class Statement:
     def __init__(self):
@@ -159,22 +159,22 @@ class Assignment(Statement,IdGenerator):
         self.prefix = case.prefix
 
     def text(self):
-        return "      %s := %s" % (self.lval, self.rval)
+        return "      {0!s} := {1!s}".format(self.lval, self.rval)
 
     def html(self):
-        return """<p>Set %s to %s.</p>""" % (self.lvalHtml(), self.rvalHtml())
+        return """<p>Set {0!s} to {1!s}.</p>""".format(self.lvalHtml(), self.rvalHtml())
 
     def lvalHtml(self):
-        return """<var title="">%s</var>""" % self.lval
+        return """<var title="">{0!s}</var>""".format(self.lval)
 
     def rvalHtml(self):
         if self.rval in constants:
             return self.rval
         elif self.variables_re.match(self.rval):
-            return """the value of <var title="%s">%s</var>""" % (
+            return """the value of <var title="{0!s}">{1!s}</var>""".format(
                 self.title_from_string(self.rval), self.rval)
         else:
-            return "\"<a href=#%s title=\"%s\">%s</a>\"" % (
+            return "\"<a href=#{0!s} title=\"{1!s}\">{2!s}</a>\"".format(
                 self.id_from_string(self.rval),
                 self.title_from_string(self.rval),
                 self.rval)
@@ -185,14 +185,14 @@ class Buffer(Statement):
         self.variable = var
 
     def text(self):
-        return "      buffer %s" % self.variable
+        return "      buffer {0!s}".format(self.variable)
 
     def html(self):
-        return """<p>Append %s to <var title="">buffer</var>.</p>
-""" % self.varHtml()
+        return """<p>Append {0!s} to <var title="">buffer</var>.</p>
+""".format(self.varHtml())
 
     def varHtml(self):
-        return """<var title="">%s</var>""" % self.variable
+        return """<var title="">{0!s}</var>""".format(self.variable)
 
 class Decrement(Statement):
     def __init__(self, var):
@@ -200,13 +200,13 @@ class Decrement(Statement):
         self.variable = var
 
     def text(self):
-        return "      dec %s" % self.variable
+        return "      dec {0!s}".format(self.variable)
 
     def html(self):
-        return """<p>Decrement %s by one.</p>""" % self.varHtml()
+        return """<p>Decrement {0!s} by one.</p>""".format(self.varHtml())
 
     def varHtml(self):
-        return """<var title="">%s</var>""" % self.variable
+        return """<var title="">{0!s}</var>""".format(self.variable)
 
 class Nop(Statement):
     def __init__(self):
@@ -225,13 +225,13 @@ class Post(Statement):
         self.target = post_target
 
     def text(self):
-        return "      post %s" % self.variable
+        return "      post {0!s}".format(self.variable)
 
     def html(self):
-        return """<p>Append %s to %s.</p>""" % (self.varHtml(), self.target)
+        return """<p>Append {0!s} to {1!s}.</p>""".format(self.varHtml(), self.target)
 
     def varHtml(self):
-        return """<var title="">%s</var>""" % self.variable
+        return """<var title="">{0!s}</var>""".format(self.variable)
 
 class Predefined(Statement,IdGenerator):
     def __init__(self, statement, prefix):
@@ -240,10 +240,10 @@ class Predefined(Statement,IdGenerator):
         self.prefix = prefix
 
     def text(self):
-        return "      %s" % self.statement
+        return "      {0!s}".format(self.statement)
 
     def html(self):
-        return """<p><a href=#%s title="%s">%s</a>.</p>""" % (self.id_from_string(self.statement),
+        return """<p><a href=#{0!s} title="{1!s}">{2!s}</a>.</p>""".format(self.id_from_string(self.statement),
        self.title_from_string(self.statement),
        self.statement.capitalize())
 
@@ -300,12 +300,12 @@ class StateMachine:
             self.state = IN_CONDITION
 
     def process_line(self, line):
-        debug("process_line(%s) in state %s" % (line, self.state))
+        debug("process_line({0!s}) in state {1!s}".format(line, self.state))
         if self.state == IN_PREAMBLE:
             var_decls = parse_var_decls.match(line)
             if var_decls is not None:
                 self.variables = var_decls.group(1).split(", ")
-                self.variables_re_str = "(%s)" % list_re(self.variables)
+                self.variables_re_str = "({0!s})".format(list_re(self.variables))
                 self.variables_re = re.compile(self.variables_re_str)
                 return
             targets = parse_targets.match(line)
@@ -318,7 +318,7 @@ class StateMachine:
             predefs = parse_defined_above.match(line)
             if predefs is not None:
                 self.predefineds = predefs.group(1).split(", ")
-                self.predefined_re = re.compile("^\s*(%s)$" % list_re(self.predefineds))
+                self.predefined_re = re.compile("^\s*({0!s})$".format(list_re(self.predefineds)))
                 return
             xrefs = parse_xref_prefix.match(line)
             if xrefs is not None:
@@ -326,7 +326,7 @@ class StateMachine:
                 return
             switch = parse_switch.match(line)
             if switch is not None:
-                self.condition_re = re.compile("^\s*(%s)=(%s|eof|[-.A-Za-z](/[A-Za-z])*)( (if|unless)( (%s|numbers are( not)? coming)))?:$" % (
+                self.condition_re = re.compile("^\s*({0!s})=({1!s}|eof|[-.A-Za-z](/[A-Za-z])*)( (if|unless)( ({2!s}|numbers are( not)? coming)))?:$".format(
                     self.variables_re_str,
                     list_re(common_microsyntaxes),
                     self.variables_re_str))
@@ -371,12 +371,12 @@ class StateMachine:
                 return
 
     def text(self):
-        return """parse using %s
-posting to: %s
-buffering to: %s
-defined above: %s
-prefix xrefs with "%s"
-%s""" % (self.variables, self.posting_to, self.buffering_to,
+        return """parse using {0!s}
+posting to: {1!s}
+buffering to: {2!s}
+defined above: {3!s}
+prefix xrefs with "{4!s}"
+{5!s}""".format(self.variables, self.posting_to, self.buffering_to,
         self.predefined_re, self.switch.prefix, self.switch.text())
 
     def html(self):

--- a/publish.py
+++ b/publish.py
@@ -9,11 +9,11 @@ from lxml import etree
 
 def invoked_incorrectly():
     specs = config.load_config().keys()
-    sys.stderr.write("Usage: python %s [%s]\n" % (sys.argv[0],'|'.join(specs)))
+    sys.stderr.write("Usage: python {0!s} [{1!s}]\n".format(sys.argv[0], '|'.join(specs)))
     exit()
 
 spaceCharacters = "".join(spaceCharacters)
-spacesRegex = re.compile("[%s]+" % spaceCharacters)
+spacesRegex = re.compile("[{0!s}]+".format(spaceCharacters))
 non_ifragment = re.compile("[^A-Za-z0-9._~!$&'()*+,;=:@/\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF\U00010000-\U0001FFFD\U00020000-\U0002FFFD\U00030000-\U0003FFFD\U00040000-\U0004FFFD\U00050000-\U0005FFFD\U00060000-\U0006FFFD\U00070000-\U0007FFFD\U00080000-\U0008FFFD\U00090000-\U0009FFFD\U000A0000-\U000AFFFD\U000B0000-\U000BFFFD\U000C0000-\U000CFFFD\U000D0000-\U000DFFFD\U000E1000-\U000EFFFD]+")
 def generateID(source, el):
     source = source.strip(spaceCharacters).lower()
@@ -30,7 +30,7 @@ def generateID(source, el):
 
     i = 0
     while utils.getElementById(el.getroottree().getroot(), id) is not None:
-        id = "%s-%i" % (source, i)
+        id = "{0!s}-{1:d}".format(source, i)
         i += 1
     utils.ids[el.getroottree().getroot()][id] = el
     return id
@@ -54,8 +54,8 @@ def main(spec, spec_dir, branch="master"):
             else:
                 spec_dir = os.path.join(conf["output"], spec)
     except KeyError:
-        sys.stderr.write("error: Must specify output directory for %s! \
-Check default-config.json.\n" % spec)
+        sys.stderr.write("error: Must specify output directory for {0!s}! \
+Check default-config.json.\n".format(spec))
         exit()
 
     cur_dir = os.path.abspath(os.path.dirname(__file__))
@@ -83,8 +83,8 @@ Check default-config.json.\n" % spec)
     try:
         boilerplate.main(succint, filtered, select, branch)
     except IOError:
-        sys.stderr.write("error: Problem loading boilerplate for %s. \
-Are you on the correct branch?\n" % spec)
+        sys.stderr.write("error: Problem loading boilerplate for {0!s}. \
+Are you on the correct branch?\n".format(spec))
         exit()
     succint.close()
 
@@ -195,7 +195,7 @@ Are you on the correct branch?\n" % spec)
     print "processing references"
     for dt in tree.findall("//dt[@id]"):
         refID = dt.get("id")
-        if refID.startswith("refs") and len(tree.findall("//a[@href='#%s']" % refID)) == 0:
+        if refID.startswith("refs") and len(tree.findall("//a[@href='#{0!s}']".format(refID))) == 0:
             next = dt.getnext()
             while next.tag != "dd":
                 next = next.getnext()
@@ -262,12 +262,12 @@ Are you on the correct branch?\n" % spec)
     if spec == 'html':
         print 'cleaning'
         from glob import glob
-        for name in glob("%s/*.html" % spec_dir):
+        for name in glob("{0!s}/*.html".format(spec_dir)):
             os.remove(name)
 
         output = StringIO()
     else:
-        output = open("%s/Overview.html" % spec_dir, 'wb')
+        output = open("{0!s}/Overview.html".format(spec_dir), 'wb')
 
     generator.toFile(tree, output, **opts)
 
@@ -283,7 +283,7 @@ Are you on the correct branch?\n" % spec)
             interface_index(output, index)
             value = value.replace("<!--INTERFACES-->\n", index.getvalue(), 1)
             index.close()
-        output = open("%s/single-page.html" % spec_dir, 'wb')
+        output = open("{0!s}/single-page.html".format(spec_dir), 'wb')
         output.write(value)
         output.close()
         value = ''
@@ -293,11 +293,11 @@ Are you on the correct branch?\n" % spec)
         spec_splitter.w3c = True
         spec_splitter.no_split_exceptions = conf.get("no_split_exceptions", False)
         spec_splitter.minimal_split_exceptions = conf.get("minimal_split_exceptions", False)
-        spec_splitter.main("%s/single-page.html" % spec_dir, spec_dir)
+        spec_splitter.main("{0!s}/single-page.html".format(spec_dir), spec_dir)
 
         print 'entities'
         entities = open(os.path.join(cur_dir, "boilerplate/entities.inc"))
-        json = open("%s/entities.json" % spec_dir, 'w')
+        json = open("{0!s}/entities.json".format(spec_dir), 'w')
         from entity_processor_json import entity_processor_json
         entity_processor_json(entities, json)
         entities.close()
@@ -309,10 +309,10 @@ Are you on the correct branch?\n" % spec)
         if not isinstance(targets, types.ListType): targets = [targets]
         if os.name == "nt":
             for target in targets:
-                os.system("xcopy /s %s %s" % (os.path.join(conf["path"], target), spec_dir))
+                os.system("xcopy /s {0!s} {1!s}".format(os.path.join(conf["path"], target), spec_dir))
         else:
             for target in targets:
-                os.system("/bin/csh -i -c '/bin/cp -R %s %s'" % (os.path.join(conf["path"], target), spec_dir))
+                os.system("/bin/csh -i -c '/bin/cp -R {0!s} {1!s}'".format(os.path.join(conf["path"], target), spec_dir))
 
     print "copying"
     if spec == "html":

--- a/spec_splitter.py
+++ b/spec_splitter.py
@@ -164,7 +164,7 @@ def main(input, output):
   # Stuff for fixing up references:
 
   def get_page_filename(name):
-      return '%s.html' % name
+      return '{0!s}.html'.format(name)
 
   # Finds all the ids and remembers which page they were on
   id_pages = {}
@@ -182,13 +182,13 @@ def main(input, output):
               id = e.get('href')[1:]
               if id in id_pages:
                   if id_pages[id] != page: # only do non-local links
-                      e.set('href', '%s#%s' % (get_page_filename(id_pages[id]), id))
+                      e.set('href', '{0!s}#{1!s}'.format(get_page_filename(id_pages[id]), id))
               else:
                   missing_warnings.add(id)
 
   def report_broken_refs():
       for id in sorted(missing_warnings):
-          print "warning: can't find target for #%s" % id
+          print "warning: can't find target for #{0!s}".format(id)
 
   pages = [] # for saving all the output, so fix_refs can be called in a second pass
 
@@ -250,8 +250,8 @@ def main(input, output):
   for heading in child_iter:
       # Handle the heading for this section
       title, name = get_heading_text_and_id(heading)
-      if name == index_page: name = 'section-%s' % name
-      if verbose: print '  <%s> %s - %s' % (heading.tag, name, title)
+      if name == index_page: name = 'section-{0!s}'.format(name)
+      if verbose: print '  <{0!s}> {1!s} - {2!s}'.format(heading.tag, name, title)
 
       page = deepcopy(doc)
       page_body = page.find('body')
@@ -295,28 +295,28 @@ def main(input, output):
       if i > 1:
           href = get_page_filename(pages[i-1][0])
           title = pages[i-1][2]
-          a = etree.XML(u'<a href="%s">\u2190 %s</a>' % (href, title))
+          a = etree.XML(u'<a href="{0!s}">\u2190 {1!s}</a>'.format(href, title))
           a.tail = u' \u2013\n   '
           nav.append(a)
-          link = etree.XML('<link href="%s" title="%s" rel="prev"/>' % (href, title))
+          link = etree.XML('<link href="{0!s}" title="{1!s}" rel="prev"/>'.format(href, title))
           link.tail = '\n  '
           head.append(link)
 
-      a = etree.XML('<a href="%s.html#contents">Table of contents</a>' % index_page)
+      a = etree.XML('<a href="{0!s}.html#contents">Table of contents</a>'.format(index_page))
       a.tail = '\n  '
       nav.append(a)
-      link = etree.XML('<link href="%s.html#contents" title="Table of contents" rel="contents"/>' % index_page)
+      link = etree.XML('<link href="{0!s}.html#contents" title="Table of contents" rel="contents"/>'.format(index_page))
       link.tail = '\n  '
       head.append(link)
 
       if i != len(pages)-1:
           href = get_page_filename(pages[i+1][0])
           title = pages[i+1][2]
-          a = etree.XML(u'<a href="%s">%s \u2192</a>' % (href, title))
+          a = etree.XML(u'<a href="{0!s}">{1!s} \u2192</a>'.format(href, title))
           a.tail = '\n  '
           nav.append(a)
           a.getprevious().tail = u' \u2013\n   '
-          link = etree.XML('<link href="%s" title="%s" rel="next"/>' % (href, title))
+          link = etree.XML('<link href="{0!s}" title="{1!s}" rel="next"/>'.format(href, title))
           link.tail = '\n  '
           head.append(link)
 
@@ -398,9 +398,9 @@ def main(input, output):
           f.write(etree.tostring(doc, pretty_print=False, method="html"))
 
   # Generate the script to fix broken links
-  f = open('%s/fragment-links.js' % (output), 'w')
-  links = ','.join("'%s':'%s'" % (k.replace("\\", "\\\\").replace("'", "\\'"), v) for (k,v) in id_pages.items())
-  f.write('var fragment_links = { ' + re.sub(r"([^\x20-\x7f])", lambda m: "\\u%04x" % ord(m.group(1)), links) + ' };\n')
+  f = open('{0!s}/fragment-links.js'.format((output)), 'w')
+  links = ','.join("'{0!s}':'{1!s}'".format(k.replace("\\", "\\\\").replace("'", "\\'"), v) for (k,v) in id_pages.items())
+  f.write('var fragment_links = { ' + re.sub(r"([^\x20-\x7f])", lambda m: "\\u{0:04x}".format(ord(m.group(1))), links) + ' };\n')
   f.write("""
   var fragid = window.location.hash.substr(1);
   if (!fragid) { /* handle section-foo.html links from the old multipage version, and broken foo.html from the new version */


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:html-tools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:html-tools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
